### PR TITLE
Added support of NimBLE-Arduino for ESP32

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -10,8 +10,15 @@
 
 [platformio]
 default_envs = 
-            arduino_nano_esp32
             nano_33_iot
+            arduino_nano_esp32
+            arduino_nano_esp32_nimble
+[env]
+framework = arduino
+monitor_speed = 115200
+lib_deps =
+    vovagorodok/ArduinoBleOTA@^1.0.0
+    https://github.com/vovagorodok/ArduinoBleChess.git#alternative1
 
 [env:nano_33_iot]
 platform = atmelsam
@@ -20,10 +27,14 @@ board = nano_33_iot
 [env:arduino_nano_esp32]
 platform = espressif32
 board = arduino_nano_esp32
-upload_protocol = dfu 
+upload_protocol = dfu
 
-framework = arduino
-monitor_speed = 115200
+[env:arduino_nano_esp32_nimble]
+platform = espressif32
+board = arduino_nano_esp32
+upload_protocol = dfu
+build_flags = 
+	-D USE_NIM_BLE_ARDUINO_LIB
 lib_deps =
-    vovagorodok/ArduinoBleOTA@^1.0.0
-    https://github.com/vovagorodok/ArduinoBleChess.git#alternative1
+	${env.lib_deps}
+	h2zero/NimBLE-Arduino@^1.4.1

--- a/src/main.ino
+++ b/src/main.ino
@@ -124,7 +124,7 @@ public:
       BleChessString move = getMoveInput().c_str();
 
       if(checkCastling(move)){
-        getMoveInput().c_str(); /* get second move from castling but do not send it: send king move only after second input */
+        getMoveInput(); /* get second move from castling but do not send it: send king move only after second input */
       }
 
       DEBUG_SERIAL.print("moved from peripheral: ");

--- a/src/main.ino
+++ b/src/main.ino
@@ -135,7 +135,7 @@ public:
         sendMove(move);
         lastPeripheralMove = move;
       }
-      skip_next_send = false; /*skip only once, then allow new move send */
+      skip_next_send = false; /* skip only once, then allow new move send */
   }
 
 private:

--- a/src/main.ino
+++ b/src/main.ino
@@ -6,7 +6,7 @@
 #include <BleChessMultiservice.h>
 #include "openchessboard.h"
 
-#define DEVICE_NAME "OCHESSBOARD" // max name size with 128 bit uuid is 11
+#define DEVICE_NAME "OPEN CHESS" // max name size with 128 bit uuid is 11
 #define DEBUG true  // set to true for debug output, false for no debug output
 #define DEBUG_SERIAL if(DEBUG)Serial
 
@@ -153,7 +153,7 @@ void setup() {
 #endif
   DEBUG_SERIAL.println("BLE init: OPENCHESSBOARD");
   initBle(DEVICE_NAME);
-  if (!ArduinoBleChess.begin("Chess board", peripheral)){
+  if (!ArduinoBleChess.begin(peripheral)){
     DEBUG_SERIAL.println("Ble chess initialization error");
   }
   if (!ArduinoBleOTA.begin(InternalStorage)) {

--- a/src/openchessboard.cpp
+++ b/src/openchessboard.cpp
@@ -175,7 +175,9 @@ String getMoveInput(void) {
 
 // wait for Start move event
   while (!mvStarted) {
+#ifndef USE_NIM_BLE_ARDUINO_LIB
     BLE.poll();
+#endif
     readHall(hallBoardState1);
 
     for (int row_index = 0; row_index < 8; row_index++) {

--- a/src/openchessboard.cpp
+++ b/src/openchessboard.cpp
@@ -207,6 +207,9 @@ String getMoveInput(void) {
 
 // wait for end move event
   while (!mvFinished ) {
+#ifndef USE_NIM_BLE_ARDUINO_LIB
+    BLE.poll();
+#endif
     readHall(hallBoardState2);
     delay(100);
     readHall(hallBoardState3);


### PR DESCRIPTION
`ArduinoBleChess` and `ArduinoBleOTA` support alternative BLE lib `NimBLE-Arduino` instead `ArduinoBLE`:  https://github.com/vovagorodok/ArduinoBleChess?tab=readme-ov-file#configuration

Difference is: `NimBLE-Arduino` use `std::string` instead Arduino's `String`. That's why created `BleChessString`